### PR TITLE
Add an index page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Kyori Javadocs</title>
+</head>
+<body>
+<script>
+    window.location.replace("https://jd.adventure.kyori.net/");
+</script>
+</body>
+</html>

--- a/404.html
+++ b/404.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
-    <title>Kyori Javadocs</title>
+    <title>Adventure Javadocs</title>
 </head>
 <body>
 <script>

--- a/404.html
+++ b/404.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="utf-8"/>
     <title>Kyori Javadocs</title>
 </head>
 <body>

--- a/index.css
+++ b/index.css
@@ -1,0 +1,42 @@
+body {
+    margin: 0;
+    background-color: #2b2b2b;
+    color: white;
+    /* this list is copypasted straight from bootstrap kek */
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-size: 24px;
+}
+
+.title {
+    margin: 0;
+    background-color: #383838;
+    text-align: center;
+    padding: 15px;
+}
+
+.header {
+    font-weight: bold;
+    text-align: center;
+    width: 100%;
+    padding-top: 20px;
+}
+
+#listContainer {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin: 15px;
+
+}
+
+#listContainer > div {
+    width: 300px;
+    background-color: #383838;
+    border-radius: 5px;
+    margin: 20px 10px;
+}
+
+a {
+    color: #99b8ff;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>Kyori Javadocs</title>
+    <style>
+        body {
+            margin: 0;
+            background-color: #2b2b2b;
+            color: white;
+            /* this list is copypasted straight from bootstrap kek */
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif,
+            "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+            font-size: 24px;
+        }
+
+        .title {
+            margin: 0;
+            background-color: #383838;
+            text-align: center;
+            padding: 15px;
+        }
+
+        .header {
+            font-weight: bold;
+            text-align: center;
+            width: 100%;
+            padding-top: 20px;
+        }
+
+        #listContainer {
+            display: flex;
+            justify-content: center;
+            flex-wrap: wrap;
+            width: 100%;
+            margin: 15px;
+            box-sizing: border-box;
+        }
+
+        #listContainer > div {
+            width: 300px;
+            background-color: #383838;
+            border-radius: 5px;
+            margin: 20px 10px;
+        }
+
+        a {
+            color: #99b8ff;
+        }
+    </style>
+</head>
+<body>
+<div class="title">Kyori Javadocs</div>
+<div id="listContainer">
+    <div class="header" style="padding-bottom: 20px">Loading...</div>
+</div>
+</body>
+
+<script>
+    const API_URL = "https://api.github.com/repos/KyoriPowered/adventure-javadocs/contents";
+
+    async function getVersions(url) {
+        let versions = await fetch(`${API_URL}/${url}`);
+        let json = await versions.json();
+        let output = "";
+        for (let obj of json.reverse()) output += `<li><a href="/${obj.path}">${obj.name}</a></li>`
+        return output;
+    }
+
+    async function load() {
+        let result = await fetch(API_URL);
+        let json = await result.json();
+        let output = "";
+        let requests = [];
+
+        for (let obj of json) {
+            if (obj.type === "dir") {
+                requests.push(getVersions(obj.name).then(versions => {
+                    output +=
+                        `<div>
+	       <div class="header">${obj.name}</div>
+	       <ul>
+	       ${versions}
+	       </ul>
+	       </div>`
+                }));
+            }
+        }
+        await Promise.all(requests);
+        document.getElementById("listContainer").innerHTML = output;
+    }
+
+    load();
+</script>
+</html>

--- a/index.html
+++ b/index.html
@@ -32,9 +32,8 @@
             display: flex;
             justify-content: center;
             flex-wrap: wrap;
-            width: 100%;
             margin: 15px;
-            box-sizing: border-box;
+
         }
 
         #listContainer > div {

--- a/index.html
+++ b/index.html
@@ -2,93 +2,15 @@
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
-    <title>Kyori Javadocs</title>
-    <style>
-        body {
-            margin: 0;
-            background-color: #2b2b2b;
-            color: white;
-            /* this list is copypasted straight from bootstrap kek */
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif,
-            "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-            font-size: 24px;
-        }
-
-        .title {
-            margin: 0;
-            background-color: #383838;
-            text-align: center;
-            padding: 15px;
-        }
-
-        .header {
-            font-weight: bold;
-            text-align: center;
-            width: 100%;
-            padding-top: 20px;
-        }
-
-        #listContainer {
-            display: flex;
-            justify-content: center;
-            flex-wrap: wrap;
-            margin: 15px;
-
-        }
-
-        #listContainer > div {
-            width: 300px;
-            background-color: #383838;
-            border-radius: 5px;
-            margin: 20px 10px;
-        }
-
-        a {
-            color: #99b8ff;
-        }
-    </style>
+    <title>Adventure Javadocs</title>
+    <link rel="stylesheet" type="text/css" href="index.css">
 </head>
 <body>
-<div class="title">Kyori Javadocs</div>
+<div class="title">Adventure Javadocs</div>
 <div id="listContainer">
     <div class="header" style="padding-bottom: 20px">Loading...</div>
 </div>
 </body>
-
-<script>
-    const API_URL = "https://api.github.com/repos/KyoriPowered/adventure-javadocs/contents";
-
-    async function getVersions(url) {
-        let versions = await fetch(`${API_URL}/${url}`);
-        let json = await versions.json();
-        let output = "";
-        for (let obj of json.reverse()) output += `<li><a href="/${obj.path}">${obj.name}</a></li>`
-        return output;
-    }
-
-    async function load() {
-        let result = await fetch(API_URL);
-        let json = await result.json();
-        let output = "";
-        let requests = [];
-
-        for (let obj of json) {
-            if (obj.type === "dir") {
-                requests.push(getVersions(obj.name).then(versions => {
-                    output +=
-                        `<div>
-	       <div class="header">${obj.name}</div>
-	       <ul>
-	       ${versions}
-	       </ul>
-	       </div>`
-                }));
-            }
-        }
-        await Promise.all(requests);
-        document.getElementById("listContainer").innerHTML = output;
-    }
-
-    load();
-</script>
+<script src="index.js"></script>
+<script>load();</script>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,32 @@
+const API_URL = "https://api.github.com/repos/KyoriPowered/adventure-javadocs/contents";
+
+async function getVersions(url) {
+    let versions = await fetch(`${API_URL}/${url}`);
+    let json = await versions.json();
+    let output = "";
+    for (let obj of json.reverse()) output += `<li><a href="/${obj.path}">${obj.name}</a></li>`
+    return output;
+}
+
+async function load() {
+    let result = await fetch(API_URL);
+    let json = await result.json();
+    let output = "";
+    let requests = [];
+
+    for (let obj of json) {
+        if (obj.type === "dir") {
+            requests.push(getVersions(obj.name).then(versions => {
+                output +=
+                    `<div>
+	       <div class="header">${obj.name}</div>
+	       <ul>
+	       ${versions}
+	       </ul>
+	       </div>`
+            }));
+        }
+    }
+    await Promise.all(requests);
+    document.getElementById("listContainer").innerHTML = output;
+}


### PR DESCRIPTION
This PR adds a dynamic index page to the site, grabbing information from the GitHub API. It's based on the page I use [for my own javadocs ](https://javadoc.lucyy.me/), with some improvements. 

Tested on Chrome and Firefox with no issues.
![image](https://user-images.githubusercontent.com/35287819/113396043-bf5d4080-9392-11eb-825c-7e0f7b0cb3f6.png)
